### PR TITLE
Add max score tracking

### DIFF
--- a/script.js
+++ b/script.js
@@ -5,6 +5,7 @@ let currentFeature;
 let selectedProvinces = [];
 let attemptCount = 0;
 let score = 0;
+let maxScore = 0;
 
 document.addEventListener('DOMContentLoaded', () => {
     document.getElementById('start-game').addEventListener('click', startGame);
@@ -31,6 +32,8 @@ function startGame() {
             allFeatures = data.features.filter(feature =>
                 selectedProvinces.includes(feature.properties.province)
             );
+            maxScore = allFeatures.length * 5;
+            updateScoreDisplay();
 
             geojsonLayer = L.geoJSON(allFeatures, {
                 style: {
@@ -49,7 +52,7 @@ function startGame() {
 function nextQuestion() {
     if (allFeatures.length === 0) {
         document.getElementById('question').textContent = 'Peli päättyi! Kaikki kunnat pelattu.';
-        document.getElementById('result').textContent = `Lopullinen pistemäärä: ${score}`;
+        document.getElementById('result').textContent = `Lopullinen pistemäärä: ${score} / ${maxScore}`;
         return;
     }
 
@@ -158,7 +161,7 @@ function updateScoreDisplay() {
         scoreDisplay.style.marginTop = '10px';
         document.querySelector('.sidebar').appendChild(scoreDisplay);
     }
-    scoreDisplay.textContent = `Pisteet: ${score}`;
+    scoreDisplay.textContent = `Pisteet: ${score} / ${maxScore}`;
 }
 
 function selectAllProvinces() {


### PR DESCRIPTION
## Summary
- track the game's maximum score based on selected municipalities
- display the score in `current/max` format

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683fda81b9d88320a3c87935a41684bc